### PR TITLE
Update unidecode issue by giving the choice to user via 'preprocess' parameter in predict

### DIFF
--- a/notebooks/example.ipynb
+++ b/notebooks/example.ipynb
@@ -2,9 +2,18 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/conda/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
    "source": [
     "import os\n",
     "import sys\n",
@@ -34,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -156,26 +165,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-01-27 15:24:44 - botocore.httpchecksum - Skipping checksum validation. Response did not contain one of the following algorithms: ['crc32', 'sha1', 'sha256'].\n",
-      "2025-01-27 15:24:44 - botocore.httpchecksum - Skipping checksum validation. Response did not contain one of the following algorithms: ['crc32', 'sha1', 'sha256'].\n",
-      "2025-01-27 15:24:44 - botocore.httpchecksum - Skipping checksum validation. Response did not contain one of the following algorithms: ['crc32', 'sha1', 'sha256'].\n",
-      "2025-01-27 15:24:45 - botocore.httpchecksum - Skipping checksum validation. Response did not contain one of the following algorithms: ['crc32', 'sha1', 'sha256'].\n",
-      "2025-01-27 15:24:45 - botocore.httpchecksum - Skipping checksum validation. Response did not contain one of the following algorithms: ['crc32', 'sha1', 'sha256'].\n"
+      "2025-02-10 17:41:41 - botocore.httpchecksum - Skipping checksum validation. Response did not contain one of the following algorithms: ['crc32', 'sha1', 'sha256'].\n",
+      "2025-02-10 17:41:41 - botocore.httpchecksum - Skipping checksum validation. Response did not contain one of the following algorithms: ['crc32', 'sha1', 'sha256'].\n",
+      "2025-02-10 17:41:41 - botocore.httpchecksum - Skipping checksum validation. Response did not contain one of the following algorithms: ['crc32', 'sha1', 'sha256'].\n",
+      "2025-02-10 17:41:42 - botocore.httpchecksum - Skipping checksum validation. Response did not contain one of the following algorithms: ['crc32', 'sha1', 'sha256'].\n",
+      "2025-02-10 17:41:42 - botocore.httpchecksum - Skipping checksum validation. Response did not contain one of the following algorithms: ['crc32', 'sha1', 'sha256'].\n"
      ]
     }
    ],
    "source": [
     "fs = s3fs.S3FileSystem(\n",
     "    client_kwargs={\"endpoint_url\": \"https://minio.lab.sspcloud.fr\"},\n",
-    "    key=os.environ[\"AWS_ACCESS_KEY_ID\"],\n",
-    "    secret=os.environ[\"AWS_SECRET_ACCESS_KEY\"],\n",
+    "    anon=True,\n",
     ")\n",
     "df = (\n",
     "    pq.ParquetDataset(\n",
@@ -196,7 +204,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-01-27 15:24:49 - botocore.httpchecksum - Skipping checksum validation. Response did not contain one of the following algorithms: ['crc32', 'sha1', 'sha256'].\n"
+      "2025-02-10 17:42:39 - botocore.httpchecksum - Skipping checksum validation. Response did not contain one of the following algorithms: ['crc32', 'sha1', 'sha256'].\n"
      ]
     },
     {

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -8,6 +8,7 @@ from sklearn.preprocessing import LabelEncoder
 
 from torchFastText import torchFastText
 from torchFastText.preprocess import clean_text_feature
+from  torchFastText.datasets import NGramTokenizer
 
 source_path = Path(__file__).resolve()
 source_dir = source_path.parent
@@ -80,7 +81,39 @@ def model():
         len_word_ngrams=len_word_ngrams,
         sparse=sparse,
     )
+def test_building(data):
+    num_tokens = 4
+    embedding_dim = 10
+    min_count = 1
+    min_n = 2
+    max_n = 5
+    len_word_ngrams = 2
+    sparse = False
+    vocab_possible_values = [None, [5, 6 , 7, 8]]
+    embedding_dim_possible_values = [[10, 20, 3, 7], 10, None]
+    num_cat_possible_values = [None, 4]
 
+
+    for vocab in vocab_possible_values:
+        for cat_embedding_dim in embedding_dim_possible_values:
+            for num_cat in num_cat_possible_values:
+                model = torchFastText(
+                    num_tokens=num_tokens,
+                    num_rows=num_tokens,
+                    embedding_dim=embedding_dim,
+                    min_count=min_count,
+                    min_n=min_n,
+                    max_n=max_n,
+                    len_word_ngrams=len_word_ngrams,
+                    sparse=sparse,
+                    categorical_embedding_dims=cat_embedding_dim,
+                    categorical_vocabulary_sizes=vocab,
+                    num_categorical_features=num_cat,
+                    num_classes = 3
+                )
+                model._build_pytorch_model()
+                assert True, "Model built without errors"
+    assert True, "Model built without errors"
 
 
 def test_model_initialization(model, data):
@@ -108,8 +141,6 @@ def test_model_initialization(model, data):
     tokenized_text_tokens, tokenized_text, id_to_token_dicts, token_to_id_dicts= tokenizer.tokenize(["Nouveau budget présenté par le gouvernement"])
     assert isinstance(tokenized_text, list)
     assert len(tokenized_text) > 0
-    #assert "gouvern </s>" in tokenized_text_tokens[0]
+
     predictions, confidence, all_scores, all_scores_letters = model.predict_and_explain(np.asarray(["Nouveau budget présenté par le gouvernement"]), 2)
     assert predictions.shape == (1, 2)
-    # "predictions" contains the predicted class for each input text, in int format. Need to decode back to have the string format
-    

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1,5 +1,6 @@
 import pytest
 from pathlib import Path
+from itertools import product
 
 import numpy as np
 import pandas as pd
@@ -8,20 +9,50 @@ from sklearn.preprocessing import LabelEncoder
 
 from torchFastText import torchFastText
 from torchFastText.preprocess import clean_text_feature
-from  torchFastText.datasets import NGramTokenizer
+from torchFastText.datasets import NGramTokenizer
 
 source_path = Path(__file__).resolve()
 source_dir = source_path.parent
 
 
-@pytest.fixture(scope='session', autouse=True)
+@pytest.fixture(scope="session", autouse=True)
 def data():
     data = {
-        'Catégorie': ['Politique', 'Politique', 'Politique', 'Politique', 'Politique', 'Politique', 'Politique', 'Politique',
-                    'International', 'International', 'International', 'International', 'International', 'International', 'International', 'International',
-                    'Célébrités', 'Célébrités', 'Célébrités', 'Célébrités', 'Célébrités', 'Célébrités', 'Célébrités', 'Célébrités',
-                    'Sport', 'Sport', 'Sport', 'Sport', 'Sport', 'Sport', 'Sport', 'Sport'],
-        'Titre': [
+        "Catégorie": [
+            "Politique",
+            "Politique",
+            "Politique",
+            "Politique",
+            "Politique",
+            "Politique",
+            "Politique",
+            "Politique",
+            "International",
+            "International",
+            "International",
+            "International",
+            "International",
+            "International",
+            "International",
+            "International",
+            "Célébrités",
+            "Célébrités",
+            "Célébrités",
+            "Célébrités",
+            "Célébrités",
+            "Célébrités",
+            "Célébrités",
+            "Célébrités",
+            "Sport",
+            "Sport",
+            "Sport",
+            "Sport",
+            "Sport",
+            "Sport",
+            "Sport",
+            "Sport",
+        ],
+        "Titre": [
             "Nouveau budget présenté par le gouvernement",
             "Élections législatives : les principaux candidats en lice",
             "Réforme de la santé : les réactions des syndicats",
@@ -53,34 +84,19 @@ def data():
             "Les performances des athlètes français aux championnats du monde",
             "Les nouveaux talents à surveiller dans le monde du sport",
             "L'impact de la technologie sur les sports traditionnels",
-            "Les grandes compétitions sportives de l'année à venir"
-        ]
+            "Les grandes compétitions sportives de l'année à venir",
+        ],
     }
     df = pd.DataFrame(data)
     labelEncoder = LabelEncoder()
-    y = labelEncoder.fit_transform(df['Catégorie'])
-    df['Titre_cleaned'] = clean_text_feature(df['Titre'])
-    X_train, X_test, y_train, y_test = train_test_split(df['Titre_cleaned'], y, test_size=0.1, stratify=y)
+    y = labelEncoder.fit_transform(df["Catégorie"])
+    df["Titre_cleaned"] = clean_text_feature(df["Titre"])
+    X_train, X_test, y_train, y_test = train_test_split(
+        df["Titre_cleaned"], y, test_size=0.1, stratify=y
+    )
     return X_train, X_test, y_train, y_test
 
-@pytest.fixture(scope='session', autouse=True)
-def model():
-    num_tokens = 4
-    embedding_dim = 10
-    min_count = 1
-    min_n = 2
-    max_n = 5
-    len_word_ngrams = 2
-    sparse = False
-    return torchFastText(
-        num_tokens=num_tokens,
-        embedding_dim=embedding_dim,
-        min_count=min_count,
-        min_n=min_n,
-        max_n=max_n,
-        len_word_ngrams=len_word_ngrams,
-        sparse=sparse,
-    )
+
 def test_building(data):
     num_tokens = 4
     embedding_dim = 10
@@ -89,58 +105,104 @@ def test_building(data):
     max_n = 5
     len_word_ngrams = 2
     sparse = False
-    vocab_possible_values = [None, [5, 6 , 7, 8]]
-    embedding_dim_possible_values = [[10, 20, 3, 7], 10, None]
+    vocab_possible_values = [None, [5, 6, 7, 8]]
+    cat_embedding_dim_possible_values = [[10, 20, 3, 7], 10, None]
+    num_cat_possible_values = [None, 4]
+    for vocab, cat_embedding_dim, num_cat in product(
+        vocab_possible_values, cat_embedding_dim_possible_values, num_cat_possible_values
+    ):
+        model = torchFastText(
+            num_tokens=num_tokens,
+            num_rows=num_tokens,
+            embedding_dim=embedding_dim,
+            min_count=min_count,
+            min_n=min_n,
+            max_n=max_n,
+            len_word_ngrams=len_word_ngrams,
+            sparse=sparse,
+            categorical_embedding_dims=cat_embedding_dim,
+            categorical_vocabulary_sizes=vocab,
+            num_categorical_features=num_cat,
+            num_classes=3,
+        )
+        model._build_pytorch_model()
+    assert True, "Model building completed without errors"
+
+
+def test_training(data):
+    num_tokens = 4
+    embedding_dim = 10
+    min_count = 1
+    min_n = 2
+    max_n = 5
+    len_word_ngrams = 2
+    sparse = False
+    vocab_possible_values = [None, [5, 6, 7, 8]]
+    cat_embedding_dim_possible_values = [[10, 20, 3, 7], 10, None]
     num_cat_possible_values = [None, 4]
 
-
-    for vocab in vocab_possible_values:
-        for cat_embedding_dim in embedding_dim_possible_values:
-            for num_cat in num_cat_possible_values:
-                model = torchFastText(
-                    num_tokens=num_tokens,
-                    num_rows=num_tokens,
-                    embedding_dim=embedding_dim,
-                    min_count=min_count,
-                    min_n=min_n,
-                    max_n=max_n,
-                    len_word_ngrams=len_word_ngrams,
-                    sparse=sparse,
-                    categorical_embedding_dims=cat_embedding_dim,
-                    categorical_vocabulary_sizes=vocab,
-                    num_categorical_features=num_cat,
-                    num_classes = 3
-                )
-                model._build_pytorch_model()
-                assert True, "Model built without errors"
-    assert True, "Model built without errors"
-
-
-def test_model_initialization(model, data):
-    assert isinstance(model, torchFastText)
-    assert model.num_tokens == 4
-    assert model.embedding_dim == 10
-    assert model.min_count == 1
-    assert model.min_n == 2
-    assert model.max_n == 5
-    assert model.len_word_ngrams == 2
-    assert not model.sparse
     X_train, X_test, y_train, y_test = data
-    model.train(
-        np.asarray(X_train),
-        np.asarray(y_train),
-        np.asarray(X_test),
-        np.asarray(y_test),
-        num_epochs=1,
-        batch_size=32,
-        lr=0.001,
-        num_workers=4
-    )
+
+    cat_data_train = np.random.randint(0, 4, (len(X_train), 4))
+    cat_data_test = np.random.randint(0, 4, (len(X_test), 4))
+    X_train_full = np.concatenate([np.asarray(X_train).reshape(-1, 1), cat_data_train], axis=1)
+    X_test_full = np.concatenate([np.asarray(X_test).reshape(-1, 1), cat_data_test], axis=1)
+    no_cat_var_model = None
+    for vocab, cat_embedding_dim, num_cat in product(
+        vocab_possible_values, cat_embedding_dim_possible_values, num_cat_possible_values
+    ):
+        print(vocab, cat_embedding_dim, num_cat)
+        model = torchFastText(
+            num_tokens=num_tokens,
+            embedding_dim=embedding_dim,
+            min_count=min_count,
+            min_n=min_n,
+            max_n=max_n,
+            len_word_ngrams=len_word_ngrams,
+            sparse=sparse,
+            categorical_embedding_dims=cat_embedding_dim,
+            categorical_vocabulary_sizes=vocab,
+            num_categorical_features=num_cat,
+            num_classes=3,
+        )
+        if (vocab is None) and (cat_embedding_dim is None) and (num_cat is None):
+            model.train(
+                np.asarray(X_train),
+                np.asarray(y_train),
+                np.asarray(X_test),
+                np.asarray(y_test),
+                num_epochs=1,
+                batch_size=32,
+                lr=0.001,
+                num_workers=4,
+            )
+            no_cat_var_model = model
+        else:
+            model.train(
+                np.asarray(X_train_full),
+                np.asarray(y_train),
+                np.asarray(X_test_full),
+                np.asarray(y_test),
+                num_epochs=1,
+                batch_size=32,
+                lr=0.001,
+                num_workers=4,
+            )
+        print("done")
     assert True, "Training completed without errors"
     tokenizer = model.tokenizer
-    tokenized_text_tokens, tokenized_text, id_to_token_dicts, token_to_id_dicts= tokenizer.tokenize(["Nouveau budget présenté par le gouvernement"])
+    tokenized_text_tokens, tokenized_text, id_to_token_dicts, token_to_id_dicts = (
+        tokenizer.tokenize(["Nouveau budget présenté par le gouvernement"])
+    )
     assert isinstance(tokenized_text, list)
     assert len(tokenized_text) > 0
 
-    predictions, confidence, all_scores, all_scores_letters = model.predict_and_explain(np.asarray(["Nouveau budget présenté par le gouvernement"]), 2)
+    predictions, confidence, all_scores, all_scores_letters = model.predict_and_explain(
+        np.asarray(["Nouveau budget présenté par le gouvernement"] + [0] * 4).reshape(1, -1), 2
+    )
+    assert predictions.shape == (1, 2)
+
+    predictions, confidence, all_scores, all_scores_letters = no_cat_var_model.predict_and_explain(
+        np.asarray(["Nouveau budget présenté par le gouvernement"]), 2
+    )
     assert predictions.shape == (1, 2)

--- a/torchFastText/datasets/tokenizer.py
+++ b/torchFastText/datasets/tokenizer.py
@@ -245,17 +245,22 @@ class NGramTokenizer:
 
         return torch.Tensor(all_indices), id_to_token, all_tokens_id
 
-    def tokenize(self, text: list[str], text_tokens=True):
+    def tokenize(self, text: list[str], text_tokens=True, preprocess=True):
         """
         Tokenize a list of sentences.
 
         Args:
-            sentence (list[str]): List of sentences.
+            text (list[str]): List of sentences.
+            text_tokens (bool): If True, return tokenized text in tokens.
+            preprocess (bool): If True, preprocess text. Needs unidecode library.
 
         Returns:
             np.array: Array of indices.
         """
-        text = clean_text_feature(text)
+
+        if preprocess:
+            text = clean_text_feature(text)
+
         tokenized_text = []
         id_to_token_dicts = []
         token_to_id_dicts = []

--- a/torchFastText/datasets/tokenizer.py
+++ b/torchFastText/datasets/tokenizer.py
@@ -245,7 +245,7 @@ class NGramTokenizer:
 
         return torch.Tensor(all_indices), id_to_token, all_tokens_id
 
-    def tokenize(self, text: list[str], text_tokens=True, preprocess=True):
+    def tokenize(self, text: list[str], text_tokens=True, preprocess=False):
         """
         Tokenize a list of sentences.
 

--- a/torchFastText/model/pytorch_model.py
+++ b/torchFastText/model/pytorch_model.py
@@ -72,14 +72,13 @@ class FastTextModel(nn.Module):
         else:
             self.average_cat_embed = False
 
-        categorical_vocabulary_sizes,
-        categorical_embedding_dims,
-        num_categorical_features = validate_categorical_inputs(
-                                                                categorical_vocabulary_sizes,
-                                                                categorical_embedding_dims,
-                                                                num_categorical_features=None
-                                                               )
-
+        categorical_vocabulary_sizes, categorical_embedding_dims, num_categorical_features = (
+            validate_categorical_inputs(
+                categorical_vocabulary_sizes,
+                categorical_embedding_dims,
+                num_categorical_features=None,
+            )
+            )
         assert isinstance(categorical_embedding_dims, list), "categorical_embedding_dims must be a list of int at this stage"
         
         if tokenizer is None:

--- a/torchFastText/model/pytorch_model.py
+++ b/torchFastText/model/pytorch_model.py
@@ -206,7 +206,7 @@ class FastTextModel(nn.Module):
         return z
 
     def predict(
-        self, text: List[str], categorical_variables: List[List[int]], top_k=1, explain=False
+        self, text: List[str], categorical_variables: List[List[int]], top_k=1, explain=False, preprocess=True
     ):
         """
         Args:
@@ -215,6 +215,7 @@ class FastTextModel(nn.Module):
                 pass to the model for inference.
             top_k (int): for each sentence, return the top_k most likely predictions (default: 1)
             explain (bool): launch gradient integration to have an explanation of the prediction (default: False)
+            preprocess (bool): If True, preprocess text. Needs unidecode library.
 
         Returns:
         if explain is False:
@@ -261,7 +262,7 @@ class FastTextModel(nn.Module):
         batch_size = len(text)
 
         indices_batch, id_to_token_dicts, token_to_id_dicts = self.tokenizer.tokenize(
-            text, text_tokens=False
+            text, text_tokens=False, preprocess=preprocess
         )
 
         padding_index = (

--- a/torchFastText/model/pytorch_model.py
+++ b/torchFastText/model/pytorch_model.py
@@ -67,6 +67,11 @@ class FastTextModel(nn.Module):
         """
         super(FastTextModel, self).__init__()
 
+        if isinstance(categorical_embedding_dims, int):
+            self.average_cat_embed = True  # if provided categorical embedding dims is an int, average the categorical embeddings before concatenating to sentence embedding
+        else:
+            self.average_cat_embed = False
+
         categorical_vocabulary_sizes,
         categorical_embedding_dims,
         num_categorical_features = validate_categorical_inputs(
@@ -75,6 +80,8 @@ class FastTextModel(nn.Module):
                                                                 num_categorical_features=None
                                                                )
 
+        assert isinstance(categorical_embedding_dims, list), "categorical_embedding_dims must be a list of int at this stage"
+        
         if tokenizer is None:
             if num_tokens is None:
                 raise ValueError("Either tokenizer or num_tokens must be provided (number of rows in the embedding matrix).")
@@ -91,13 +98,9 @@ class FastTextModel(nn.Module):
         self.embedding_dim = embedding_dim
         self.direct_bagging = direct_bagging
         self.sparse = sparse
-        self.average_cat_embed = False
 
         if categorical_embedding_dims is not None:
             self.categorical_embedding_dims = categorical_embedding_dims
-
-            if len(set(categorical_embedding_dims)) == 1:
-                self.average_cat_embed = True  # if categorical embedding dims are the same, we average them before concatenating to the sentence embedding
 
         self.embeddings = (
             nn.Embedding(

--- a/torchFastText/torchFastText.py
+++ b/torchFastText/torchFastText.py
@@ -665,7 +665,7 @@ class torchFastText:
 
         return self.trainer.test(self.pytorch_model, test_dataloaders=dataloader, verbose=False)
 
-    def predict(self, X, top_k=1, preprocess=True):
+    def predict(self, X, top_k=1, preprocess=False):
         """
         Predicts the "top_k" classes of the input text.
 

--- a/torchFastText/torchFastText.py
+++ b/torchFastText/torchFastText.py
@@ -662,17 +662,25 @@ class torchFastText:
 
         return self.trainer.test(self.pytorch_model, test_dataloaders=dataloader, verbose=False)
 
-    def predict(self, X, top_k=1):
+    def predict(self, X, top_k=1, preprocess=True):
         """
         Predicts the "top_k" classes of the input text.
 
         Args:
             X (np.ndarray): Array of shape (N,d) with the first column being the text and the rest being the categorical variables.
             top_k (int): Number of classes to predict (by order of confidence).
+            preprocess (bool): Whether to preprocess the text before predicting.
 
         Returns:
             np.ndarray: Array of shape (N,top_k)
         """
+
+        if preprocess:
+            logger.info(
+                "Preprocessing is set to True. Input text will be preprocessed, requiring NLTK and Unidecode librairies."
+            )
+        else:
+            logger.info("Preprocessing is set to False. Input text will not be preprocessed and fed as is to the model.")
 
         if not self.trained:
             raise Exception("Model must be trained first.")
@@ -687,7 +695,9 @@ class torchFastText:
         else:
             assert self.pytorch_model.no_cat_var == True
 
-        return self.pytorch_model.predict(text, categorical_variables, top_k=top_k)
+        return self.pytorch_model.predict(text, categorical_variables, top_k=top_k,
+                                          preprocess=preprocess
+                                          )
 
     def predict_and_explain(self, X, top_k=1):
         if not self.trained:

--- a/torchFastText/utilities/checkers.py
+++ b/torchFastText/utilities/checkers.py
@@ -80,15 +80,17 @@ def validate_categorical_inputs(categorical_vocabulary_sizes: List[int],
             num_categorical_features = len(categorical_vocabulary_sizes)
         
     assert num_categorical_features is not None, "num_categorical_features should be inferred at this point."
-
-    if isinstance(categorical_embedding_dims, int):
-        categorical_embedding_dims = [
-            categorical_embedding_dims
-        ] * num_categorical_features
-    elif not isinstance(categorical_embedding_dims, list):
-        raise TypeError("categorical_embedding_dims must be an int or a list of int")
     
-    assert isinstance(categorical_embedding_dims, list), "categorical_embedding_dims must be a list of int at this point"
+    # "Transform" embedding dims into a suitable list, or stay None
+    if categorical_embedding_dims is not None:
+        if isinstance(categorical_embedding_dims, int):
+            categorical_embedding_dims = [
+                categorical_embedding_dims
+            ] * num_categorical_features
+        elif not isinstance(categorical_embedding_dims, list):
+            raise TypeError("categorical_embedding_dims must be an int or a list of int")
+    
+    assert isinstance(categorical_embedding_dims, list) or categorical_embedding_dims is None, "categorical_embedding_dims must be a list of int at this point"
 
     return categorical_vocabulary_sizes, categorical_embedding_dims, num_categorical_features
 

--- a/torchFastText/utilities/checkers.py
+++ b/torchFastText/utilities/checkers.py
@@ -56,9 +56,12 @@ def validate_categorical_inputs(categorical_vocabulary_sizes: List[int],
                                 num_categorical_features: int = None):
     
     if categorical_vocabulary_sizes is None:
+        logger.warning(
+            "No categorical_vocabulary_sizes. It will be inferred later."
+        )
         return None, None, None
     
-    if categorical_vocabulary_sizes is not None:
+    else:
         if not isinstance(categorical_vocabulary_sizes, list):
             raise TypeError("categorical_vocabulary_sizes must be a list of int")
 
@@ -75,29 +78,18 @@ def validate_categorical_inputs(categorical_vocabulary_sizes: List[int],
                 )
         else:
             num_categorical_features = len(categorical_vocabulary_sizes)
-    else:
-        logger.warning(
-            "categorical_embedding_dims provided but not categorical_vocabulary_sizes. It will be inferred later"
-        )
+        
+    assert num_categorical_features is not None, "num_categorical_features should be inferred at this point."
 
-    if num_categorical_features is not None:
-        if isinstance(categorical_embedding_dims, int):
-            categorical_embedding_dims = [
-                categorical_embedding_dims
-            ] * num_categorical_features
-        elif not isinstance(categorical_embedding_dims, list):
-            raise TypeError("categorical_embedding_dims must be an int or a list of int")
-        elif len(categorical_embedding_dims) != num_categorical_features:
-            raise ValueError(
-                f"len(categorical_embedding_dims)({len(categorical_embedding_dims)}) "
-                f"should be equal to num_categorical_features({num_categorical_features})"
-            )
-    elif isinstance(categorical_embedding_dims, list):
-        num_categorical_features = len(categorical_embedding_dims)
-    else:
-        logger.warning(
-            "categorical_embedding_dims provided as int but not num_categorical_features. It will be inferred later"
-        )
+    if isinstance(categorical_embedding_dims, int):
+        categorical_embedding_dims = [
+            categorical_embedding_dims
+        ] * num_categorical_features
+    elif not isinstance(categorical_embedding_dims, list):
+        raise TypeError("categorical_embedding_dims must be an int or a list of int")
+    
+    assert isinstance(categorical_embedding_dims, list), "categorical_embedding_dims must be a list of int at this point"
+
     return categorical_vocabulary_sizes, categorical_embedding_dims, num_categorical_features
 
 class NumpyJSONEncoder(json.JSONEncoder):


### PR DESCRIPTION
Resolving #27 

In predict, text _should_ be preprocessed in the same way it has been preprocessed for training to enhance performance. But it is not required per se.

We let the processing to the user's choice, via the parameter `preprocess (bool)`. If true, it will call `clean_text_feature` from the preprocess subpackage, that requires `unidecode` and `nltk`.

If false, the text will be given directly to the model, and everything remains independent from these two optional dependencies.

