### PR TITLE
[README] [bug] Learning rate should be defined in train method

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ model.train(
     X_val=val_data,
     y_val=val_labels,
     num_epochs=10,
-    batch_size=64
+    batch_size=64,
+    lr=4e-3
 )
 # Make predictions
 predictions = model.predict(test_data)


### PR DESCRIPTION
Reproducible example below.

Solution is easy: adding a learning parameter in the README.
Still an error afterwards but it is a different issue

## Reprex

Made by `ChatGPT`

```python
import pandas as pd
from torchFastText import torchFastText

df_train = pd.DataFrame({
    "description_ean": [
        "biere noir olive cereal limonade proteine",
        "noir compote barre",
        "vin olive proteine biscuit fromage",
        "barre saucisson bio vin",
        "noir poulet jambon bio"
    ],
    "variete": [
        "2.7.9.6.6.9999",
        "7.7.7.5.2.9999",
        "4.4.5.5.6.9999",
        "11.9.5.4.6.9999",
        "8.9.1.4.6.9999"
    ]
})

df_test  = df_train.copy() #don't care about this one

model = torchFastText(
    num_tokens=1000000,
    embedding_dim=100,
    min_count=5,
    min_n=3,
    max_n=6,
    len_word_ngrams=True,
    sparse=True
)

# Train the model
model.train(
    X_train=df_train.loc[:, "description_ean"].values,
    y_train=df_train['variete'].values,
    X_val=df_test.loc[:, "description_ean"].values,
    y_val=df_test['variete'].values,
    num_epochs=10,
    batch_size=64,
    #lr=0.01  # Learning rate
)
```